### PR TITLE
Add support for executing a server-side script

### DIFF
--- a/lib/ex_orient/db.ex
+++ b/lib/ex_orient/db.ex
@@ -29,7 +29,6 @@ defmodule ExOrient.DB do
       case MarcoPolo.command(worker, query, params: params) do
         {:ok, %{response: response}} -> {:ok, response}
         {:error, error} -> {:error, error}
-        _ -> {:error, "Something went badly wrong."}
       end
     end)
   end
@@ -38,6 +37,23 @@ defmodule ExOrient.DB do
   An alias for command/1
   """
   def exec({query, params}), do: command(query, params: params)
+
+  @doc """
+  Execute a server-side script. `type` can be either `"SQL"` or `"Javascript"`. `str` is the
+  string of the script you want to run. Example:
+
+      DB.script("SQL", "begin; let v = create vertex V set name = 'test'; commit; return $v")
+      {:ok, %MarcoPolo.Document{fields: %{"name" => "test"}}}
+
+  """
+  def script(type, str) do
+    :poolboy.transaction(:marco_polo, fn(worker) ->
+      case MarcoPolo.script(worker, type, str) do
+        {:ok, %{response: response}} -> {:ok, response}
+        {:error, error} -> {:error, error}
+      end
+    end)
+  end
 
   defdelegate select(field), to: CRUD
   defdelegate select(field, opts), to: CRUD

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExOrient.Mixfile do
 
   def project do
     [app: :ex_orient,
-     version: "1.1.1",
+     version: "1.2.0",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/ex_orient/db_test.exs
+++ b/test/ex_orient/db_test.exs
@@ -31,4 +31,15 @@ defmodule ExOrient.DBTest do
     DB.drop(class: "ExOrientDBTest2", unsafe: true) |> DB.exec()
     DB.drop(class: "exorient_member_of", unsafe: true) |> DB.exec()
   end
+
+  @tag :db
+  test "run a script" do
+    assert {:ok, %MarcoPolo.Document{}} = DB.script("SQL", """
+    begin
+    let v = create vertex V set name = 'test'
+    delete vertex V where name = 'test'
+    commit
+    return $v
+    """)
+  end
 end


### PR DESCRIPTION
Run scripts through:

```elixir
ExOrient.DB.script("SQL", """
begin
let v = create vertex V set name = 'Paul'
commit
return $v
""")
```